### PR TITLE
Hotfix/concurrency and NSDate fix

### DIFF
--- a/Core/example/ios/example/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Core/example/ios/example/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/Core/ios/Core/AWSRNCognitoCredentials.m
+++ b/Core/ios/Core/AWSRNCognitoCredentials.m
@@ -17,11 +17,11 @@
 @implementation AWSRNCognitoCredentials{
     NSMutableDictionary *options;
     AWSCognitoCredentialsProvider *credentialProvider;
-    NSLock* lock;
     AWSRNHelper *helper;
 }
 
 @synthesize bridge = _bridge;
+@synthesize methodQueue = _methodQueue;
 
 typedef void (^ Block)(id, int);
 
@@ -32,6 +32,8 @@ const NSString *SECRET_KEY = @"secret_key";
 const NSString *SESSION_TOKEN = @"session_token";
 const NSString *EXPIRATION = @"expiration";
 const NSString *IDENTITY_ID = @"identity_id";
+
+static NSMutableDictionary* callbacks;
 
 RCT_EXPORT_MODULE(AWSRNCognitoCredentials)
 
@@ -55,22 +57,35 @@ RCT_EXPORT_METHOD(clear){
 }
 
 RCT_EXPORT_METHOD(getCredentialsAsync:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
-    [[credentialProvider credentials] continueWithBlock:^id(AWSTask *task) {
-        if (task.exception){
-            dispatch_async(dispatch_get_main_queue(), ^{
-                @throw [NSException exceptionWithName:task.exception.name reason:task.exception.reason userInfo:task.exception.userInfo];
-            });
-        }
-        if (task.error) {
-            reject([NSString stringWithFormat:@"%ld",task.error.code],task.error.description,task.error);
-        }
-        else {
-            AWSCredentials *cred = (AWSCredentials*) task.result;
-            NSDictionary *dict = @{@"AccessKey":cred.accessKey,@"SecretKey":cred.secretKey,@"SessionKey":cred.sessionKey,@"Expiration":cred.expiration};
-            resolve(dict);
-        }
-        return nil;
-    }];
+
+    //start a separate thread for this to avoid blocking the component queue, since
+    //it will have to comunicate with the javascript in the mean time while trying to get the list of logins
+
+    NSString* queueName = [NSString stringWithFormat:@"%@.getCredentialsAsyncQueue",
+                           [NSString stringWithUTF8String:dispatch_queue_get_label(self.methodQueue)]
+                           ];
+    dispatch_queue_t concurrentQueue = dispatch_queue_create([queueName UTF8String], DISPATCH_QUEUE_CONCURRENT);
+
+    dispatch_async(concurrentQueue, ^{
+
+        [[credentialProvider credentials] continueWithBlock:^id(AWSTask *task) {
+            if (task.exception){
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    @throw [NSException exceptionWithName:task.exception.name reason:task.exception.reason userInfo:task.exception.userInfo];
+                });
+            }
+            if (task.error) {
+                reject([NSString stringWithFormat:@"%ld",task.error.code],task.error.description,task.error);
+            }
+            else {
+                AWSCredentials *cred = (AWSCredentials*) task.result;
+                NSDictionary *dict = @{@"AccessKey":cred.accessKey,@"SecretKey":cred.secretKey,@"SessionKey":cred.sessionKey,@"Expiration":cred.expiration};
+                resolve(dict);
+            }
+            return nil;
+        }];
+
+    });
 }
 
 RCT_EXPORT_METHOD(getIdentityIDAsync:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
@@ -115,17 +130,17 @@ RCT_EXPORT_METHOD(initWithOptions:(NSDictionary *)inputOptions)
 #pragma mark - AWSIdentityProviderManager
 
 - (AWSTask<NSDictionary<NSString *, NSString *> *> *)logins{
-    if (!lock){
-        lock = [[NSLock alloc]init];
-    }
     return [[AWSTask taskWithResult:nil] continueWithSuccessBlock:^id _Nullable(AWSTask * _Nonnull task) {
         __block NSArray* arr;
-        [self sendMessage:[[NSMutableDictionary alloc]init] toChannel:@"LoginsRequestedEvent" withCallback:^(NSArray* response){
+
+        dispatch_semaphore_t sendMessageSemaphore = dispatch_semaphore_create(0);
+
+        [self sendMessage:[[NSMutableDictionary alloc]init] toChannel:@"LoginsRequestedEvent" semaphore:sendMessageSemaphore withCallback:^(NSArray* response) {
             arr = response;
-            [lock unlock];
         }];
-        [lock lock];
-        [lock unlock];
+
+        dispatch_semaphore_wait(sendMessageSemaphore, DISPATCH_TIME_FOREVER);
+
         if (![[arr objectAtIndex:0]isKindOfClass:[NSDictionary class]]){
             return [[NSDictionary alloc]init];
         }
@@ -143,18 +158,48 @@ RCT_EXPORT_METHOD(initWithOptions:(NSDictionary *)inputOptions)
     NSMutableDictionary *dict = [[NSMutableDictionary alloc]init];
     [dict setValue:[notification.userInfo valueForKey:AWSCognitoNotificationPreviousId] forKey:@"Previous"];
     [dict setValue:[notification.userInfo valueForKey:AWSCognitoNotificationNewId] forKey:@"Current"];
-    [self sendMessage:dict toChannel:@"IdentityChange" withCallback:nil];
+    [self sendMessage:dict toChannel:@"IdentityChange"];
 }
 
--(void)sendMessage:(NSMutableDictionary*)info toChannel:(NSString*)channel withCallback:(RCTResponseSenderBlock)callback{
-    if ([channel isEqualToString:@"LoginsRequestedEvent"]){
-        [lock lock];
-        [info setValue:callback forKey:@"ReturnInfo"];
+
+RCT_EXPORT_METHOD(sendCallbackResponse:(NSString *)callbackId response:(NSArray *)response){
+    NSDictionary* callbackInfo = [callbacks objectForKey:callbackId];
+    if(callbackInfo) {
+        RCTResponseSenderBlock callback = callbackInfo[@"callback"];
+        dispatch_semaphore_t semaphore = callbackInfo[@"semaphore"];
+        [callbacks removeObjectForKey:callbackId];
+
+        callback(response);
+        dispatch_semaphore_signal(semaphore);
     }
+    else{
+        NSLog(@"WARN callback id not found!");
+    }
+}
+
+-(NSString*) registerCallBack:(RCTResponseSenderBlock)callback semaphore:(dispatch_semaphore_t)semaphore {
+    if (!callbacks){
+        callbacks = [@{} mutableCopy];
+    }
+    NSString* callbackId = [[NSUUID UUID] UUIDString];
+    callbacks[callbackId] = @{
+                              @"callback": callback ? callback : (^(NSArray *response) { }),
+                              @"semaphore":semaphore
+                              };
+    return callbackId;
+}
+
+-(void)sendMessage:(NSMutableDictionary*)info toChannel:(NSString*)channel{
     [self.bridge.eventDispatcher
      sendAppEventWithName:channel
      body:[info copy]
      ];
+}
+
+-(void)sendMessage:(NSMutableDictionary*)info toChannel:(NSString*)channel semaphore:(dispatch_semaphore_t)semaphore withCallback:(RCTResponseSenderBlock)callback  {
+    NSString * callbackId = [self registerCallBack:callback semaphore:semaphore];
+    [info setValue:callbackId forKey:@"callbackId"];
+    [self sendMessage:info toChannel:channel];
 }
 
 -(NSMutableDictionary*)setLogins:(NSMutableDictionary*)reactLogins{
@@ -185,8 +230,5 @@ RCT_EXPORT_METHOD(initWithOptions:(NSDictionary *)inputOptions)
     }
     return logins;
 }
-
-
-
 
 @end

--- a/Core/ios/Core/AWSRNCognitoCredentials.m
+++ b/Core/ios/Core/AWSRNCognitoCredentials.m
@@ -14,11 +14,15 @@
 //
 #import "AWSRNCognitoCredentials.h"
 
+@interface AWSRNCognitoCredentials()
+    @property (nonatomic, readonly) NSDateFormatter *dateFormatterISO8601;
+@end
+
 @implementation AWSRNCognitoCredentials{
     NSMutableDictionary *options;
     AWSCognitoCredentialsProvider *credentialProvider;
     AWSRNHelper *helper;
-    NSDateFormatter* _dateFormatterISO8601;
+    NSDateFormatter *_dateFormatterISO8601;
 }
 
 @synthesize bridge = _bridge;

--- a/Core/ios/Core/AWSRNCognitoCredentials.m
+++ b/Core/ios/Core/AWSRNCognitoCredentials.m
@@ -125,7 +125,7 @@ RCT_EXPORT_METHOD(getIdentityIDAsync:(RCTPromiseResolveBlock)resolve rejecter:(R
             reject([NSString stringWithFormat:@"%ld",task.error.code],task.error.description,task.error);
         }
         else {
-            resolve(@{@"identityid":task.result});
+            resolve(@{@"identityId":task.result});
         }
         return nil;
     }];

--- a/Core/package.json
+++ b/Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-react-native-core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A React Native wrapper for AWS SDK for Cognito Identity",
   "main": "./src/index.js",
   "files": [

--- a/Core/src/AWSCognitoCredentials.js
+++ b/Core/src/AWSCognitoCredentials.js
@@ -42,10 +42,14 @@ export default class AWSCognitoCredentials{
     this.RNC_AMAZON_PROVIDER = "AmazonProvider"
     this.RNC_TWITTER_PROVIDER = "TwitterProvider"
     this.RNC_COGNITO_PROVIDER = "CognitoProvider"
+
     //set up delegate for IdentityProvider
     if (Platform.OS === 'ios'){
       listener.addListener("LoginsRequestedEvent", async event => {
-        event.ReturnInfo([this.getLogins()]);
+        //FIX: can't pass a callback in the event like this.
+        //event.ReturnInfo([this.getLogins()]);
+        const {callbackId} = event;
+        cognitoClient.sendCallbackResponse(callbackId, [this.getLogins()]);
       });
     }
     //Set up Notifications for Identity Changes

--- a/Core/src/AWSCognitoCredentials.js
+++ b/Core/src/AWSCognitoCredentials.js
@@ -45,11 +45,9 @@ export default class AWSCognitoCredentials{
 
     //set up delegate for IdentityProvider
     if (Platform.OS === 'ios'){
-      listener.addListener("LoginsRequestedEvent", async event => {
-        //FIX: can't pass a callback in the event like this.
-        //event.ReturnInfo([this.getLogins()]);
-        const {callbackId} = event;
-        cognitoClient.sendCallbackResponse(callbackId, [this.getLogins()]);
+      listener.addListener("LoginsRequestedEvent", async {callbackId} => {
+        const logins = [await Promise.resolve(this.getLogins())];
+        cognitoClient.sendCallbackResponse(callbackId, logins);
       });
     }
     //Set up Notifications for Identity Changes


### PR DESCRIPTION
Hi,
This PR hopefully fixed the issues described here: https://github.com/awslabs/aws-sdk-react-native/issues/3
1. I have removed NSLock
2. Using a separate queue when invoking getCredentialsAsync() - this allows the back-and-forth required when during this call the native code calls the javascript to get the list of logins.
3. passing dates as strings down the wire
