### PR TITLE
fix syntax error

### DIFF
--- a/Core/src/AWSCognitoCredentials.js
+++ b/Core/src/AWSCognitoCredentials.js
@@ -45,7 +45,7 @@ export default class AWSCognitoCredentials{
 
     //set up delegate for IdentityProvider
     if (Platform.OS === 'ios'){
-      listener.addListener("LoginsRequestedEvent", async {callbackId} => {
+      listener.addListener("LoginsRequestedEvent", async (callbackId) => {
         const logins = [await Promise.resolve(this.getLogins())];
         cognitoClient.sendCallbackResponse(callbackId, logins);
       });


### PR DESCRIPTION
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1519): SyntaxError: SyntaxError C:/github/Thriveful/node_modules/aws-sdk-react-native-core/src/AWSCognitoCredentials.js: Unexpected token, expected , (48:57)

`listener.addListener("LoginsRequestedEvent", async {callbackId} => {`
becomes
`listener.addListener("LoginsRequestedEvent", async (callbackId) => {`